### PR TITLE
Loci の自動アップデート公開物を linguist-generated として除外

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,8 @@
 *.png binary
 *.jpg binary
 *.ico binary
+*.apk binary
+
+# Auto-published by hgsk/Loci's CD workflow (.github/workflows/android.yml).
+# Exclude from language stats and keep PR/commit diffs quiet.
+public/Loci/update/** linguist-generated=true diff=false


### PR DESCRIPTION
## Summary

- [hgsk/Loci](https://github.com/hgsk/Loci) の CD ワークフローが、端末向け自動アップデート用の
  `app-debug.apk` / `version.json` を今後 `public/Loci/update/` に自動コミットするようになります
  （対応PR: https://github.com/hgsk/Loci/pull/new/claude/hgsk-github-io-deploy-6sdr72）。
- `.gitattributes` に `public/Loci/update/**` を `linguist-generated=true diff=false` として追加し、
  自動生成された APK / JSON が言語統計や通常の PR 差分に出てこないようにしました。
  あわせて `*.apk binary` も明示しました。

このリポジトリ自体のビルド（Astro）やページ内容に変更はありません。
`public/` 配下は既存のビルド設定でそのまま静的配信されるため、追加のワークフロー変更は不要です。

## Test plan

- [ ] Loci 側 PR がマージ後、CI が `public/Loci/update/version.json` をこのリポジトリに push することを確認
- [ ] `https://hgsk.github.io/Loci/update/version.json` にアクセスできることを確認
- [ ] `public/Loci/update/` 配下のファイルが GitHub 上で generated 表示になり、通常の diff に埋もれないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFvp64dtar4Xk2JRy3zTZ)_