### PR TITLE
Loci 1.0.202607150313を公開

### DIFF
--- a/public/Loci/update/version.json
+++ b/public/Loci/update/version.json
@@ -1,0 +1,7 @@
+{
+  "versionCode": 29734753,
+  "versionName": "1.0.202607150313",
+  "apkUrl": "https://hgsk.github.io/Loci/update/app-debug.apk",
+  "sha256": "7b3bf2480baf40b6ea181b93cd6ae678554ed27b2b6b551dd1a52caf6a2656e2",
+  "commit": "be4b344fdb328bed7ec7768b10cd473304d59d75"
+}


### PR DESCRIPTION
## 公開内容

- `hgsk/Loci` のAndroid Build #29385227165で生成された署名済みAPKを追加
- `public/Loci/update/version.json` をversionCode `29734753`へ更新
- APK SHA-256: `7b3bf2480baf40b6ea181b93cd6ae678554ed27b2b6b551dd1a52caf6a2656e2`
- 対応コミット: `be4b344fdb328bed7ec7768b10cd473304d59d75`

Artifact内のSHA-256とローカル計算値が一致することを確認済みです。
